### PR TITLE
Update failed geoCode logic

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -44,8 +44,7 @@ functions:
       - schedule:
           name: orestarScraper
           description: 'Pull Ted Wheeler campaign contribution data every 12 hours'
-          rate: rate(1 minute)
-          # rate: rate(12 hours)
+          rate: rate(12 hours)
       # - http: 
       #     method: get
       #     path: orestarScraper

--- a/services/addContribution.ts
+++ b/services/addContribution.ts
@@ -28,22 +28,23 @@ export default async (contribution: IContributionSummary, contributionRepo: Repo
             state: entry.state,
             zip: entry.zip,
           });
-          geoCode = {
-            type: 'Point',
-            coordinates,
-          };
-          if (doGeocode || orestarDataHasBeenUpdated) {
+          
+          if (coordinates) {
+            geoCode = {
+              type: 'Point',
+              coordinates,
+            };
             Object.assign(oaeContribution, {
               addressPoint: geoCode,
             });
-            await contributionRepo.save(oaeContribution);
           }
+          await contributionRepo.save(oaeContribution);
         } catch (error) {
           failedGeocoding = true;
           reportError(error);
         }
       }
-      if (failedGeocoding) {
+      if (failedGeocoding || orestarDataHasBeenUpdated) {
         await contributionRepo.save(oaeContribution);
       }
     }).catch(async () => {
@@ -55,12 +56,14 @@ export default async (contribution: IContributionSummary, contributionRepo: Repo
           state: oaeContribution.state,
           zip: oaeContribution.zip,
         });
-        Object.assign(oaeContribution, {
-          addressPoint: {
-            type: 'Point',
-            coordinates: geoCode,
-          },
-        });
+        if (geoCode) {
+          Object.assign(oaeContribution, {
+            addressPoint: {
+              type: 'Point',
+              coordinates: geoCode,
+            },
+          });
+        }
       } catch (error) {
         reportError(error);
       }

--- a/services/addContribution.ts
+++ b/services/addContribution.ts
@@ -49,23 +49,25 @@ export default async (contribution: IContributionSummary, contributionRepo: Repo
       }
     }).catch(async () => {
       // find failed, this is an insert! row does not exist so we geocode.
-      try {
-        const geoCode = await geocodeAddressAsync({
-          address1: oaeContribution.address1,
-          city: oaeContribution.city,
-          state: oaeContribution.state,
-          zip: oaeContribution.zip,
-        });
-        if (geoCode) {
-          Object.assign(oaeContribution, {
-            addressPoint: {
-              type: 'Point',
-              coordinates: geoCode,
-            },
+      if (!oaeContribution.addressPoint) {
+        try {
+          const geoCode = await geocodeAddressAsync({
+            address1: oaeContribution.address1,
+            city: oaeContribution.city,
+            state: oaeContribution.state,
+            zip: oaeContribution.zip,
           });
+          if (geoCode) {
+            Object.assign(oaeContribution, {
+              addressPoint: {
+                type: 'Point',
+                coordinates: geoCode,
+              },
+            });
+          }
+        } catch (error) {
+          reportError(error);
         }
-      } catch (error) {
-        reportError(error);
       }
       await contributionRepo.save(oaeContribution);
     });

--- a/services/geocodeContributions.ts
+++ b/services/geocodeContributions.ts
@@ -75,7 +75,7 @@ export async function geocodeAddressAsync(attrs: {
   if (process.env.NODE_ENV === 'test') {
     return;
   }
-  const address1 = attrs.address1.replace(/\s/g, '+');
+  const address1 = attrs.address1.replace(/\s/g, '+').replace(/#/g, '');
 
   const url = `https://maps.googleapis.com/maps/api/geocode/json?address=${address1},+${attrs.city},+${attrs.state},+${attrs.zip}&key=${process.env.GOOGLE_GIS_KEY}`;
   const request = await fetch(url);

--- a/services/parseAndSaveContributionData.ts
+++ b/services/parseAndSaveContributionData.ts
@@ -133,6 +133,18 @@ export async function parseAndSaveContributionData(xlsFilename: string): Promise
       country: orestarEntry.Country,
     };
 
+    // Orestar will auto-aggregate contributions of ~$100 and set the Contributor/Payee to Miscellaneous Cash Contributions $100 and under, while excluding Review By Name, Review Date, etc. This sets the address for these contributions to the State of Oregon's Elections Division address in Salem for OAE visualization purposes. OAE participants must submit each contribution independently, so this only applies to Orestar data. See: https://sos.oregon.gov/elections/Documents/orestarTransFiling.pdf page 13.
+    if (orestarEntry['Contributor/Payee'].includes('Miscellaneous Cash Contributions $100 and under')) {
+      oaeEntry.address1 = '255 Capitol St NE Suite 501';
+      oaeEntry.city = 'Salem';
+      oaeEntry.state = 'OR';
+      oaeEntry.zip = '97310';
+      oaeEntry.addressPoint = {
+        type: 'Point',
+        coordinates: [-123.0287679, 44.9392561]
+      };
+    }
+
     try {
       await addContribution(oaeEntry, contributionRepo);      
     } catch (error) {

--- a/services/parseAndSaveContributionData.ts
+++ b/services/parseAndSaveContributionData.ts
@@ -108,9 +108,9 @@ export async function parseAndSaveContributionData(xlsFilename: string): Promise
   });
   const sheetName = workbook.SheetNames[0];
   const orestarData: OrestarEntry[] = XLSX.utils.sheet_to_json(workbook.Sheets[sheetName]);
+  console.log(`total contributions: ${orestarData.length}.`);
 
-  // TODO: remove slice
-  Promise.all(orestarData.slice(0, 2).map(async (orestarEntry: OrestarEntry) => {
+  Promise.all(orestarData.map(async (orestarEntry: OrestarEntry) => {
     const oaeEntry: IContributionSummary = {
       orestarOriginalId: orestarEntry['Original Id'],
       orestarTransactionId: orestarEntry['Tran Id'],

--- a/services/parseAndSaveContributionData.ts
+++ b/services/parseAndSaveContributionData.ts
@@ -135,10 +135,12 @@ export async function parseAndSaveContributionData(xlsFilename: string): Promise
 
     // Orestar will auto-aggregate contributions of ~$100 and set the Contributor/Payee to Miscellaneous Cash Contributions $100 and under, while excluding Review By Name, Review Date, etc. This sets the address for these contributions to the State of Oregon's Elections Division address in Salem for OAE visualization purposes. OAE participants must submit each contribution independently, so this only applies to Orestar data. See: https://sos.oregon.gov/elections/Documents/orestarTransFiling.pdf page 13.
     if (orestarEntry['Contributor/Payee'].includes('Miscellaneous Cash Contributions $100 and under')) {
+      oaeEntry.contributorType = ContributorType.INDIVIDUAL;
       oaeEntry.address1 = '255 Capitol St NE Suite 501';
       oaeEntry.city = 'Salem';
       oaeEntry.state = 'OR';
       oaeEntry.zip = '97310';
+      oaeEntry.country = 'United States';
       oaeEntry.addressPoint = {
         type: 'Point',
         coordinates: [-123.0287679, 44.9392561]

--- a/tests/services/addContribution.test.ts
+++ b/tests/services/addContribution.test.ts
@@ -153,4 +153,38 @@ describe('addContribution', () => {
       })
     })
   })
+  describe('findOneOrFail called, undefined geoCode', () => {
+    beforeEach(() => {
+      geoStub = sinon.stub(geoService, 'geocodeAddressAsync').resolves(undefined);
+      findOneOrFailSpy = sinon.stub()
+      saveSpy = sinon.stub()
+    })
+    afterEach(() => {
+      sinon.restore()
+      repository = null
+    })
+    it('findOneOrFail: geoCode throws error', async () => {
+      const contribution = newContributionAsync();
+      repository = {
+        findOneOrFail: async (args: any) => {
+          findOneOrFailSpy(args)
+          return contribution
+        },
+        save: async (args) => {
+          saveSpy(args)
+        }
+      }
+      await addContribution(contribution, (repository as Repository<unknown>))
+      expect(findOneOrFailSpy.called).to.equal(true)
+      expect(saveSpy.called).to.equal(true)
+      const findCall = findOneOrFailSpy.getCall(0)
+      const saveCall = saveSpy.getCall(0)
+      expect(findCall.args[0]).to.equal("1")
+      expect(geoStub.called).to.equal(true)
+      expect(saveCall.args[0]).to.deep.equal({
+        ...contribution,
+        "errors": [],
+      })
+    })
+  })
 })

--- a/tests/services/addContribution.test.ts
+++ b/tests/services/addContribution.test.ts
@@ -119,4 +119,38 @@ describe('addContribution', () => {
       expect(geoStub.called).to.equal(false)
     })
   })
+  describe('findOneOrFail called, failed geoCode', () => {
+    beforeEach(() => {
+      geoStub = sinon.stub(geoService, 'geocodeAddressAsync').rejects('Error geocoding');
+      findOneOrFailSpy = sinon.stub()
+      saveSpy = sinon.stub()
+    })
+    afterEach(() => {
+      sinon.restore()
+      repository = null
+    })
+    it('findOneOrFail: geoCode throws error', async () => {
+      const contribution = newContributionAsync();
+      repository = {
+        findOneOrFail: async (args: any) => {
+          findOneOrFailSpy(args)
+          return contribution
+        },
+        save: async (args) => {
+          saveSpy(args)
+        }
+      }
+      await addContribution(contribution, (repository as Repository<unknown>))
+      expect(findOneOrFailSpy.called).to.equal(true)
+      expect(saveSpy.called).to.equal(true)
+      const findCall = findOneOrFailSpy.getCall(0)
+      const saveCall = saveSpy.getCall(0)
+      expect(findCall.args[0]).to.equal("1")
+      expect(geoStub.called).to.equal(true)
+      expect(saveCall.args[0]).to.deep.equal({
+        ...contribution,
+        "errors": [],
+      })
+    })
+  })
 })


### PR DESCRIPTION
This PR refactors the geoCoding logic and sets a default address for aggregated contributions marked as "Miscellaneous Cash Contributions and under":

> Orestar will auto-aggregate contributions of ~$100 and set the Contributor/Payee to Miscellaneous Cash Contributions $100 and under, while excluding Review By Name, Review Date, etc. This sets the address for these contributions to the State of Oregon's Elections Division address in Salem for OAE visualization purposes. OAE participants must submit each contribution independently, so this only applies to Orestar data. See: https://sos.oregon.gov/elections/Documents/orestarTransFiling.pdf page 13.